### PR TITLE
Made changes to Ul width to fix smooshed icons on mobile safari browsers

### DIFF
--- a/landing-page/src/components/sections/vision/Vision.tsx
+++ b/landing-page/src/components/sections/vision/Vision.tsx
@@ -1,8 +1,8 @@
 import styled from 'styled-components';
-import twitter from '../../assets/twitter.svg';
-import discord from '../../assets/discord.svg';
-import telegram from '../../assets/whiteTelegram.png';
-import orangeBars from '../../assets/orange_bars_community.svg';
+import twitter from '../../../assets/twitter.svg';
+import discord from '../../../assets/discord.svg';
+import telegram from '../../../assets/whiteTelegram.png';
+import orangeBars from '../../../assets/orange_bars_community.svg';
 
 function Community() {
   return (


### PR DESCRIPTION
# YFD-Frontend

### What was done in this pull request (link to issue with `#<issue_number>`):

### Before openeing a pull request, please ensure:

- [ ] Add media queries to ensure responsive view for any screen size
- [ ] Every image has alt tag
- [ ] No information is lost at any screen or text size
- [ ] Page(s) can be navigated with only keyboard
- [ ] Aria labels as necessary
