### PR TITLE
Raised radial gradient on page so it doesn't overflow past the bottom

### DIFF
--- a/landing-page/src/components/background/RadialGradientBottom.tsx
+++ b/landing-page/src/components/background/RadialGradientBottom.tsx
@@ -12,17 +12,14 @@ const Radial = styled.div`
   width: 300px;
   height: 300px;
   left: -190px;
-  top: 1520px;
+  top: 1400px;
   background: radial-gradient(50% 50% at 50% 50%, rgba(65, 97, 223, 0.2) 0%, rgba(62, 94, 255, 0) 100%);
   
-  @media(min-width: 395px){
-    top: 1470px;
-  }
   @media(min-width: 425px){
     width: 340px;
     height: 340px;
     left: -210px;
-    top: 1600px;
+    top: 1500px;
   }
   @media(min-width: 756px){
     background: radial-gradient(50% 50% at 50% 50%, rgba(65, 97, 223, 0.2) 0%, rgba(66, 92, 222, 0) 100%);


### PR DESCRIPTION
# YFD-Frontend

### What was done in this pull request (link to issue with `#<issue_number>`): Fixed RadialGradientBottom.tsx so it no longer flows past the bottom of the page

### Before openeing a pull request, please ensure:

- [ ] Add media queries to ensure responsive view for any screen size
- [ ] Every image has alt tag
- [ ] No information is lost at any screen or text size
- [ ] Page(s) can be navigated with only keyboard
- [ ] Aria labels as necessary
