### PR TITLE
Added a basic keyframe and animation to the discord component to animate the blue fill

### DIFF
--- a/landing-page/src/components/sections/footer/SocialIcons.tsx
+++ b/landing-page/src/components/sections/footer/SocialIcons.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled, {keyframes} from 'styled-components';
 import {ReactComponent as Twitter} from '../../../assets/twitter.svg';
 import {ReactComponent as Discord} from '../../../assets/discord.svg';
 import {ReactComponent as Telegram} from '../../../assets/Telegram.svg';
@@ -54,6 +54,12 @@ const Li = styled.li`
   display: flex;
 `
 
+const colorChangeBlue = keyframes`
+  100%{
+    fill: #1F43BF;
+  }
+`
+
 const StyledDiscord = styled(Discord)`
   width: 100%;
   height: 50px;
@@ -61,7 +67,7 @@ const StyledDiscord = styled(Discord)`
   padding: 0;
 
   &:hover path{
-    fill: #1F43BF;
+    animation: ${colorChangeBlue} .15s linear forwards;
   }
 `
 
@@ -73,7 +79,7 @@ const StyledTwitter = styled(Twitter)`
   z-index: 0;
 
   &:hover path{
-    fill: #1F43BF;
+    animation: ${colorChangeBlue} .15s linear forwards;
   }
 `
 
@@ -84,7 +90,7 @@ const StyledTelegram = styled(Telegram)`
   padding: 0;
 
   &:hover path{
-    fill: #1F43BF;
+    animation: ${colorChangeBlue} .15s linear forwards;
   }
 `
 

--- a/landing-page/src/components/sections/vision/Vision.tsx
+++ b/landing-page/src/components/sections/vision/Vision.tsx
@@ -157,13 +157,10 @@ const Li = styled.li`
 `
 
 const colorChangeBlue = keyframes`
-  0%{
-    /* opacity: 0; */
-  }100%{
+  100%{
     fill: #1F43BF;
   }
 `
-
 
 const StyledDiscord = styled(Discord)`
   height: 50px;
@@ -171,7 +168,7 @@ const StyledDiscord = styled(Discord)`
   padding: 0;
 
   &:hover path{
-    animation: ${colorChangeBlue} .2s linear forwards;
+    animation: ${colorChangeBlue} .15s linear forwards;
   }
 `
 
@@ -182,7 +179,7 @@ const StyledTwitter = styled(Twitter)`
   z-index: 0;
 
   &:hover path{
-    fill: #1F43BF;
+    animation: ${colorChangeBlue} .15s linear forwards;
   }
 `
 
@@ -192,7 +189,7 @@ const StyledTelegram = styled(Telegram)`
   padding: 0;
 
   &:hover path{
-    fill: #1F43BF;
+    animation: ${colorChangeBlue} .15s linear forwards;
   }
 `
 


### PR DESCRIPTION
# YFD-Frontend

### What was done in this pull request (link to issue with `#<issue_number>`):

### Before openeing a pull request, please ensure:

- [ ] Add media queries to ensure responsive view for any screen size
- [ ] Every image has alt tag
- [ ] No information is lost at any screen or text size
- [ ] Page(s) can be navigated with only keyboard
- [ ] Aria labels as necessary
